### PR TITLE
Fix npm start electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "rimraf dist && webpack --config config/webpack.prod.js --progress --profile --bail",
     "postinstall": "typings install",
     "prepare": "cp -a electron/. dist",
-    "electron": "prepare && electron dist",
+    "electron": "npm run prepare && electron dist",
     "package": "npm run build && npm run prepare && ./node_modules/electron-packager/cli.js dist App --platform=darwin --arch=all --out=app --overwrite"
   },
   "licenses": [


### PR DESCRIPTION
`npm start electron` was failing because of a typo.
