### PR TITLE
fix npm prepare task failing on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "pree2e": "webdriver-manager update",
     "e2e": "protractor",
     "build": "ng build && cp -R src/public dist/public",
-    "prepare": "cp -a electron/. dist",
+    "prepare": "cp electron/* dist",
     "electron": "npm run prepare && electron dist",
     "package": "npm run build && npm run prepare && ./node_modules/electron-packager/cli.js dist App --platform=darwin --arch=all --out=dist-app --overwrite"
   },


### PR DESCRIPTION
npm run prepare was failing on my windows machine with  _'.' is not recognized as an internal or external command_

`cp electron/* dist` should work across platforms 